### PR TITLE
Define PTHREAD_STACK_MIN for Intel Compilers

### DIFF
--- a/src/read_abatch.c
+++ b/src/read_abatch.c
@@ -151,6 +151,7 @@
  ** Nov 10, 2009 - Pthread on solaris fix
  ** May 26, 2010 - Multichannel CEL file support initiated 
  ** Sept 18, 2013 -  improve 64bit support for read_abatch
+ ** Jun 22, 2016 - Define PTHREAD_STACK_MIN if missing (e.g. Intel compiler) (DCT)
  ** 
  *************************************************************/
  

--- a/src/read_abatch.c
+++ b/src/read_abatch.c
@@ -177,6 +177,12 @@
 #include <limits.h>
 #include <unistd.h>
 
+// Intel Compiler doesn't have PTHREAD_STACK_MIN in limits.h
+//Set to 16K - (Linux standard for x86 / x86_64 (4 x 4K pages)
+#ifndef PTHREAD_STACK_MIN
+#define PTHREAD_STACK_MIN 16384
+#endif
+
 pthread_mutex_t mutex_R;
 int n_probesets;
 int *n_probes = NULL;


### PR DESCRIPTION
We use Intel ComposerXE compilers to build R on our HPC system. In this configuration affyio cannot install as the Intel limits.h does not include PTHREAD_STACK_MIN.

Added macro to define PTHREAD_STACK_MIN as 16384 if it's not already set. This is the default value on x86 / x86_64 linux, equivalent to 4 \* 4K pages.

Tested working on icpc version 15.0.0
